### PR TITLE
Add disable login environment toggle

### DIFF
--- a/app/init.py
+++ b/app/init.py
@@ -3,17 +3,20 @@
 import os
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
-
+from routes import (
+    api_bp,
+    main_bp,
+)
 db = SQLAlchemy()
 
 
 def _env_flag(name: str, default: str = "false") -> bool:
     """Return a boolean for the given environment variable.
 
-    Accepts truthy strings such as "1", "true", "yes", or "on" (case-insensitive).
+    Accepts only "true" (case insensitive) as True, else it is False
     """
 
-    return os.getenv(name, default).lower() in {"1", "true", "yes", "on"}
+    return os.getenv(name, default).lower() in {"true"}
 
 
 def create_app():
@@ -33,15 +36,9 @@ def create_app():
     app.config["DISABLE_LOG_IN"] = _env_flag("DISABLE_LOG_IN")
 
     db.init_app(app)
-    from routes import (
-        api_bp,
-        main_bp,
-        yt_dl_bp,
-    )  # pylint: disable=import-outside-toplevel
 
     app.register_blueprint(api_bp)
     app.register_blueprint(main_bp)
-    app.register_blueprint(yt_dl_bp)
 
     with app.app_context():
         db.create_all()

--- a/app/init.py
+++ b/app/init.py
@@ -3,10 +3,7 @@
 import os
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
-from routes import (
-    api_bp,
-    main_bp,
-)
+
 db = SQLAlchemy()
 
 
@@ -21,6 +18,9 @@ def _env_flag(name: str, default: str = "false") -> bool:
 
 def create_app():
     """Create and configure the Flask application."""
+    # pylint: disable=import-outside-toplevel
+    from routes import api_bp, main_bp
+
     app = Flask(__name__)
 
     # Initialise configuration variables

--- a/app/init.py
+++ b/app/init.py
@@ -6,6 +6,16 @@ from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()
 
+
+def _env_flag(name: str, default: str = "false") -> bool:
+    """Return a boolean for the given environment variable.
+
+    Accepts truthy strings such as "1", "true", "yes", or "on" (case-insensitive).
+    """
+
+    return os.getenv(name, default).lower() in {"1", "true", "yes", "on"}
+
+
 def create_app():
     """Create and configure the Flask application."""
     app = Flask(__name__)
@@ -14,11 +24,21 @@ def create_app():
     app.secret_key = os.environ["SECRET_KEY"]
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///users.db"
     app.config["SQLALCHEMY_TRACK_NOTIFICATIONS"] = False
-    app.config["UPLOAD_FOLDER"] = os.path.join(app.root_path, 'static', 'download_files')
-    app.config["PROJECTS_JSON_FILE"] = os.path.join(app.root_path, 'instance', 'projects.json')
+    app.config["UPLOAD_FOLDER"] = os.path.join(
+        app.root_path, "static", "download_files"
+    )
+    app.config["PROJECTS_JSON_FILE"] = os.path.join(
+        app.root_path, "instance", "projects.json"
+    )
+    app.config["DISABLE_LOG_IN"] = _env_flag("DISABLE_LOG_IN")
 
     db.init_app(app)
-    from routes import api_bp, main_bp, yt_dl_bp  # pylint: disable=import-outside-toplevel
+    from routes import (
+        api_bp,
+        main_bp,
+        yt_dl_bp,
+    )  # pylint: disable=import-outside-toplevel
+
     app.register_blueprint(api_bp)
     app.register_blueprint(main_bp)
     app.register_blueprint(yt_dl_bp)

--- a/app/models.py
+++ b/app/models.py
@@ -20,7 +20,6 @@ class User(db.Model):
     password = db.Column(db.String(256), nullable=False)
     role = db.Column(db.Integer, nullable=False)
 
-
     def set_password(self, password):
         """
         Set the user's password by hashing the provided plain text.
@@ -29,7 +28,6 @@ class User(db.Model):
             password (str): The plain text password to hash.
         """
         self.password = generate_password_hash(password)
-
 
     def check_password(self, password):
         """

--- a/app/routes.py
+++ b/app/routes.py
@@ -21,7 +21,6 @@ from utils import get_project_from_filename, load_projects
 
 main_bp = Blueprint("main", __name__)
 api_bp = Blueprint("api", __name__)
-yt_dl_bp = Blueprint("yt_dl", __name__, url_prefix="/yt_dl")
 
 
 @main_bp.before_app_request
@@ -30,7 +29,7 @@ def enforce_disabled_authentication():
     if not current_app.config.get("DISABLE_LOG_IN", False):
         return None
 
-    if session:
+    if session.keys():
         session.clear()
 
     if request.endpoint in {"main.login", "main.signup", "main.logout"}:
@@ -87,9 +86,6 @@ def login():
     On POST, validates credentials and logs in the user. On GET,
     renders the login page.
     """
-    if current_app.config.get("DISABLE_LOG_IN", False):
-        return redirect(url_for("main.index"))
-
     if request.method == "POST":
         username = request.form["username"]
         password = request.form["password"]
@@ -111,8 +107,6 @@ def signup():
     On POST, creates a new user if the username does not exist. On GET,
     renders the signup page.
     """
-    if current_app.config.get("DISABLE_LOG_IN", False):
-        return redirect(url_for("main.index"))
 
     if request.method == "POST":
         username = request.form["username"]

--- a/app/templates/index.jinja
+++ b/app/templates/index.jinja
@@ -9,11 +9,9 @@
 
     <p> Welcome to my website </p>
 
-    {% if disable_log_in %}
-        <p id="error">Log in and registration are currently disabled.</p>
-    {%elif loggedIn == false%}
+    {%if disable_log_in == false and loggedIn == false%}
         <a href="/login" class="links">Login</a> | <a href="/signup" class="links">Register</a>
-    {%elif loggedIn == true%}
+    {%elif disable_log_in == false and loggedIn == true%}
         <b>Logged in as {{username}}</b> | <a href="/logout" class="links">Logout</a>
     {%endif%}
     <br>
@@ -62,11 +60,9 @@
         {%endif%}
     </ul>
 
-    {%if disable_log_in %}
-        <p id="error">Log in and registration are disabled; only public projects are visible.</p>
-    {%elif loggedIn == false%}
+    {%if disable_log_in == false and loggedIn == false%}
         <p id="error"> to view private projects you must log in! </p>
-    {%elif amount_able_to_view != projects|length - public_project_count %}
+    {%elif disable_log_in == false and amount_able_to_view != projects|length - public_project_count %}
         <p id="error"> some private projects are hidden! </p>
     {%endif%}
 

--- a/app/templates/index.jinja
+++ b/app/templates/index.jinja
@@ -9,7 +9,9 @@
 
     <p> Welcome to my website </p>
 
-    {%if loggedIn == false%}
+    {% if disable_log_in %}
+        <p id="error">Log in and registration are currently disabled.</p>
+    {%elif loggedIn == false%}
         <a href="/login" class="links">Login</a> | <a href="/signup" class="links">Register</a>
     {%elif loggedIn == true%}
         <b>Logged in as {{username}}</b> | <a href="/logout" class="links">Logout</a>
@@ -60,7 +62,9 @@
         {%endif%}
     </ul>
 
-    {%if loggedIn == false%}
+    {%if disable_log_in %}
+        <p id="error">Log in and registration are disabled; only public projects are visible.</p>
+    {%elif loggedIn == false%}
         <p id="error"> to view private projects you must log in! </p>
     {%elif amount_able_to_view != projects|length - public_project_count %}
         <p id="error"> some private projects are hidden! </p>

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,6 +4,7 @@
 import json
 from flask import current_app
 
+
 def get_project_from_filename(filename, projects):
     """
     Retrieve a project based on its download link derived from the filename.
@@ -20,6 +21,7 @@ def get_project_from_filename(filename, projects):
         if project.get("download_link") == f"/download/{filename}":
             return project
     return None
+
 
 def load_projects():
     """


### PR DESCRIPTION
## Summary
- add a DISABLE_LOG_IN configuration flag and helper to parse boolean environment variables
- automatically clear sessions, redirect login/signup/logout attempts, and hide authentication links when login is disabled
- format codebase with Black for consistency

## Testing
- ruff check app
- python -m compileall app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b22aaa1d88330a03761f9aa4a8468)